### PR TITLE
Using t-tests - Match Corner counts do not include matches where a team gets zero corners

### DIFF
--- a/course/lessons/plot_t_test.py
+++ b/course/lessons/plot_t_test.py
@@ -46,17 +46,15 @@ teams_df = teams_df.rename(columns={"wyId": "teamId"})
 # Preparing the dataset
 # ----------------------------
 #
-# First, we take out corners. Then, we sum them by team. We also merge it together with team dataframe to keep their names.
+# First, we group all the events for each team. Then, for each team group we sum the number of corners. We also merge it together with team dataframe to keep their names.
 # Then we repeat the same, but calculate corners taken by each team per game. 
-    
-#get corners
-corners = train.loc[train["subEventName"] == "Corner"]
+
 #count corners by team
-corners_by_team = corners.groupby(['teamId']).size().reset_index(name='counts')
+corners_by_team = train.groupby(by=['teamId']).apply(lambda grp: (grp['subEventName']=='Corner').sum()).reset_index(name='counts')
 #merge with team name
 summary = corners_by_team.merge(teams_df[["name", "teamId"]], how = "left", on = ["teamId"])
 #count corners by team by game
-corners_by_game = corners.groupby(['teamId', "matchId"]).size().reset_index(name='counts')
+corners_by_game = train.groupby(by=['matchId', 'teamId']).apply(lambda grp: (grp['subEventName']=='Corner').sum()).reset_index(name='counts')
 #merge with team name
 summary2 = corners_by_game.merge(teams_df[["name", "teamId"]], how = "left", on = ["teamId"])
 
@@ -162,7 +160,7 @@ FormatFigure(ax)
 from scipy.stats import ttest_ind
 t, pvalue  = ttest_ind(a=liverpool_corners, b=everton_corners, equal_var=True)
 
-print("The t-staistic is %.2f and the P-value is %.2f."%(t,pvalue))
+print("The t-statistic is %.2f and the P-value is %.2f."%(t,pvalue))
 if pvalue < 0.05:
     print("We reject null hypothesis - Liverpool took different number of corners per game than Everton")
 else:

--- a/course/lessons/plot_t_test.py
+++ b/course/lessons/plot_t_test.py
@@ -54,7 +54,7 @@ corners_by_team = train.groupby(by=['teamId']).apply(lambda grp: (grp['subEventN
 #merge with team name
 summary = corners_by_team.merge(teams_df[["name", "teamId"]], how = "left", on = ["teamId"])
 #count corners by team by game
-corners_by_game = train.groupby(by=['matchId', 'teamId']).apply(lambda grp: (grp['subEventName']=='Corner').sum()).reset_index(name='counts')
+corners_by_game = train.groupby(by=['teamId', 'matchId']).apply(lambda grp: (grp['subEventName']=='Corner').sum()).reset_index(name='counts')
 #merge with team name
 summary2 = corners_by_game.merge(teams_df[["name", "teamId"]], how = "left", on = ["teamId"])
 


### PR DESCRIPTION
### Bug
I think there may be a bug in the way corners per team per match is counted. In a match where a team gets no corners, the data is ignored instead of being counted as zero. Everton is an example team that played a match where they got zero corners.
The problem originates in this line (which is before the code that counts the corners by team, and by team by match):
`corners = train.loc[train["subEventName"] == "Corner"]`
This means that for any team match combinations with no corners the data is dropped here, prior to calculating the counts. Therefore, zero counts cannot happen.

### Impact
Most calculated numbers for Everton are incorrect i.e. the number of corners per match, the standard error of corners per match, the t-statistic and the p-value from the two-sample 2 sided t-test. However, the conclusion from the two-sample 2 sided t-test is not impacted.

### Minimal Reproducing Example
```
# simulate events data from 2 matches
# Match 1: A vs B - A has 0 corners, B has 1 corner
# Match 2: C vs D - C has 1 corner, D has 2 corners

train = pd.DataFrame({'matchId':[1, 1, 2, 2, 2, 2],
                      'teamId': [ 'A', 'B', 'C', 'C', 'D', 'D'],
                      'subEventName': ['Pass', 'Corner', 'Corner', 'Pass', 'Corner', 'Corner']})
corners = train.loc[train['subEventName']=='Corner']
corners_by_game = corners.groupby(['matchId', 'teamId']).size().reset_index(name='counts')
corners_by_game.sort_values(by=['matchId', 'teamId'])
```
Current Behaviour - corner counts: B 1, C 1, D 2 (A has no count)
Expected Behaviour - corner counts:  A 0, B 1, C 1, D 2 (A has a count of 0) 

### Possible Fix
The corner filtering and counting operations should take place after grouping, instead of before. Unfortunately, this is a bit more complex than the original code, so the code comments may need to be amended.
```
corners_by_team = train.groupby(by=['teamId']).apply(lambda grp: (grp['subEventName']=='Corner').sum()).reset_index(name='counts')
corners_by_game = train.groupby(by=['matchId', 'teamId']).apply(lambda grp: (grp['subEventName']=='Corner').sum()).reset_index(name='counts')
```

### Also
Fixed typo `statistic `spelling.
