### PR TITLE
Repair README.md to properly render markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,37 @@
 This is the course webpage for Soccermatics: mathematical modelling of football course.
 
 To build the site locally you need to install:
-
+```
+cd Soccermatics
 conda install sphinx
 pip install sphinx-gallery
 pip install sphinxcontrib.youtube
 pip install myst_parser
 pip install sphinx_rtd_theme
 conda env update --file environment.yml 
+```
+Install the following modules to prevent errors echoing during build, if these not already present in your environment:
 
+```
+pip install pandas
+pip install matlpotlib
+pip install statsmodels
+pip install mplsoccer
+pip install numpy
+pip install joblib
+pip install linkify
+pip install linkify-it-py
+pip install scikit-learn
+pip install xgboost
+pip install tensorflow
+```
 
-Then you can make it with:
+You can then build the documentation:
+```
+cd course
 make clean
 make html
-
+```
 
 
 All code, including code in notebooks, but not including reuse of 


### PR DESCRIPTION
* Added `cd` command to move into repo dir after checkout.
* Placed commands into markdown code blocks to provide proper rendering.
* Added section detailing additional `pip install` commands to avoid warnings echoing during build due to missing modules.