### PR TITLE
Add code copy button extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,37 @@
 This is the course webpage for Soccermatics: mathematical modelling of football course.
 
 To build the site locally you need to install:
-
+```
+cd Soccermatics
 conda install sphinx
 pip install sphinx-gallery
 pip install sphinxcontrib.youtube
 pip install myst_parser
 pip install sphinx_rtd_theme
 conda env update --file environment.yml 
+```
+Install the following modules to prevent errors echoing during build, if these not already present in your environment:
 
+```
+pip install pandas
+pip install matlpotlib
+pip install statsmodels
+pip install mplsoccer
+pip install numpy
+pip install joblib
+pip install linkify
+pip install linkify-it-py
+pip install scikit-learn
+pip install xgboost
+pip install tensorflow
+```
 
-Then you can make it with:
+You can then build the documentation:
+```
+cd course
 make clean
 make html
-
+```
 
 
 All code, including code in notebooks, but not including reuse of 

--- a/course/source/conf.py
+++ b/course/source/conf.py
@@ -20,7 +20,8 @@ author = 'David Sumpter and Aleksander Andrzejewski'
 extensions = ['sphinx.ext.mathjax',
               'sphinx_gallery.gen_gallery',
               'sphinxcontrib.youtube',
-              'myst_parser'
+              'myst_parser',
+              'sphinx_copybutton',
               ]
 
 source_suffix = {

--- a/environment.yml
+++ b/environment.yml
@@ -41,3 +41,4 @@ dependencies:
       - sphinxcontrib-youtube
       - myst-parser==0.18.1
       - ruptures
+      - sphinx-copybutton


### PR DESCRIPTION
Submitting this PR to make it easier to cut/paste code snippets.

* Install the [sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/) extension.
* Amend `environment.yml` to indicate adding the [sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/) package.